### PR TITLE
[14.0][HACK] base_tier_validation: remove raise and set pass

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -328,7 +328,9 @@ class TierValidation(models.AbstractModel):
                 and not rec._check_allow_write_under_validation(vals)
                 and not rec._context.get("skip_validation_check")
             ):
-                raise ValidationError(_("The operation is under validation."))
+                # raise ValidationError(_("The operation is under validation."))
+                # HACHK MIGRATION EPA
+                pass
             if rec._allow_to_remove_reviews(vals):
                 new_self.mapped("review_ids").unlink()
         res = super(TierValidation, new_self).write(vals)


### PR DESCRIPTION
Hack relacionado com a migração da EPA, para ignorar erros relacionados ao base_tier_validation com o modelo `tier_review`

cc @marcelsavegnago 